### PR TITLE
Refine chaos transport and add simulation example

### DIFF
--- a/cmd/sim/main.go
+++ b/cmd/sim/main.go
@@ -1,5 +1,57 @@
 package main
 
-func main() {
+import (
+	"bytes"
+	"fmt"
+	"time"
 
+	"github.com/juanpablocruz/maep/pkg/materialize"
+	"github.com/juanpablocruz/maep/pkg/model"
+	"github.com/juanpablocruz/maep/pkg/node"
+	"github.com/juanpablocruz/maep/pkg/transport"
+)
+
+// sim runs two in-memory nodes and prints their final state after a short
+// exchange. It is useful for verifying that the replication algorithm
+// converges even when wrapped in Chaos endpoints.
+func main() {
+	sw := transport.NewSwitch()
+	epA, _ := sw.Listen("A")
+	epB, _ := sw.Listen("B")
+	epAHB, _ := sw.Listen("A_hb")
+	epBHB, _ := sw.Listen("B_hb")
+
+	chaosA := transport.WrapChaos(epA, transport.ChaosConfig{Up: true})
+	chaosB := transport.WrapChaos(epB, transport.ChaosConfig{Up: true})
+	chaosAHB := transport.WrapChaos(epAHB, transport.ChaosConfig{Up: true})
+	chaosBHB := transport.WrapChaos(epBHB, transport.ChaosConfig{Up: true})
+
+	nA := node.New("A", chaosA, "B", 200*time.Millisecond)
+	nB := node.New("B", chaosB, "A", 200*time.Millisecond)
+	nA.AttachHB(chaosAHB)
+	nB.AttachHB(chaosBHB)
+
+	nA.Start()
+	nB.Start()
+	defer nA.Stop()
+	defer nB.Stop()
+	defer chaosA.Close()
+	defer chaosB.Close()
+	defer chaosAHB.Close()
+	defer chaosBHB.Close()
+
+	var actA, actB model.ActorID
+	copy(actA[:], bytes.Repeat([]byte{0xA1}, 16))
+	copy(actB[:], bytes.Repeat([]byte{0xB2}, 16))
+
+	nA.Put("x", []byte("v1"), actA)
+	nB.Put("y", []byte("v2"), actB)
+
+	time.Sleep(2 * time.Second)
+
+	snapA := materialize.Snapshot(nA.Log)
+	snapB := materialize.Snapshot(nB.Log)
+
+	fmt.Printf("A state: %v\n", snapA)
+	fmt.Printf("B state: %v\n", snapB)
 }

--- a/cmd/tuidemo/main.go
+++ b/cmd/tuidemo/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -925,21 +926,9 @@ func truncateSegList(sids []segment.ID, max int) string {
 }
 
 func parseFloat(s string) float64 {
-	f := 0.0
-	sign := 1.0
-	if strings.HasPrefix(s, "-") {
-		sign = -1
-		s = s[1:]
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
 	}
-	for _, r := range s {
-		if r == '.' {
-			break
-		} // keep it simple; you can use strconv if you prefer
-		if r >= '0' && r <= '9' {
-			f = f*10 + float64(r-'0')
-		} else {
-			break
-		}
-	}
-	return f * sign
+	return f
 }

--- a/pkg/transport/chaos_test.go
+++ b/pkg/transport/chaos_test.go
@@ -1,0 +1,122 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestChaosUpDown(t *testing.T) {
+	sw := NewSwitch()
+	a, err := sw.Listen("A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := sw.Listen("B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	chaos := WrapChaos(a, ChaosConfig{Up: false, Seed: 1})
+	defer chaos.Close()
+
+	if err := chaos.Send("B", []byte("hi")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled when link down, got %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if _, ok := b.Recv(ctx); ok {
+		t.Fatalf("expected no frame when link down")
+	}
+	if chaos.GetConfig().Up {
+		t.Fatalf("GetConfig.Up should report false")
+	}
+
+	chaos.SetUp(true)
+	if !chaos.GetConfig().Up {
+		t.Fatalf("GetConfig.Up should report true after SetUp")
+	}
+	if err := chaos.Send("B", []byte("hi")); err != nil {
+		t.Fatalf("send after SetUp: %v", err)
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	got, ok := b.Recv(ctx2)
+	if !ok || string(got) != "hi" {
+		t.Fatalf("recv mismatch: ok=%v got=%q", ok, got)
+	}
+}
+
+func TestChaosDup(t *testing.T) {
+	sw := NewSwitch()
+	a, err := sw.Listen("A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := sw.Listen("B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chaos := WrapChaos(a, ChaosConfig{Up: true, Dup: 1, Seed: 1})
+	defer chaos.Close()
+	defer b.Close()
+
+	if err := chaos.Send("B", []byte("x")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for i := 0; i < 2; i++ {
+		got, ok := b.Recv(ctx)
+		if !ok || string(got) != "x" {
+			t.Fatalf("recv %d: ok=%v got=%q", i, ok, got)
+		}
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel2()
+	if _, ok := b.Recv(ctx2); ok {
+		t.Fatalf("expected only two frames")
+	}
+}
+
+func TestChaosLoss(t *testing.T) {
+	sw := NewSwitch()
+	a, err := sw.Listen("A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := sw.Listen("B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chaos := WrapChaos(a, ChaosConfig{Up: true, Loss: 1, Seed: 1})
+	defer chaos.Close()
+	defer b.Close()
+
+	if err := chaos.Send("B", []byte("y")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if _, ok := b.Recv(ctx); ok {
+		t.Fatalf("expected frame to be dropped")
+	}
+}
+
+func TestChaosSendError(t *testing.T) {
+	sw := NewSwitch()
+	a, err := sw.Listen("A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chaos := WrapChaos(a, ChaosConfig{Up: true})
+	defer chaos.Close()
+
+	// No endpoint listening on B so Send should surface the error
+	err = chaos.Send("B", []byte("z"))
+	if err == nil {
+		t.Fatalf("expected send error for unknown destination")
+	}
+}


### PR DESCRIPTION
## Summary
- propagate send errors and avoid double-loss in ChaosEP
- parse net command probabilities with `strconv` so decimals work
- add unit test and a small in-memory simulation program

## Testing
- `go test ./...`
- `go run ./cmd/sim`


------
https://chatgpt.com/codex/tasks/task_e_68962c555af08321b6dbeba120554905