### PR TITLE
Review specs and fix code bugs

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -456,6 +456,9 @@ func (n *Node) recvLoop() {
 		case protoport.PongMsg:
 			n.emit(EventHB, map[string]any{"dir": "<-tcp"})
 			n.onPong()
+		case protoport.SyncEndMsg:
+			// Peer indicates end of sync session
+			n.endSessionTo(from, false, "peer_end")
 		case protoport.SummaryRespMsg:
 			n.handleSummaryResp(from, msg.S)
 		case protoport.SummaryReqMsg:

--- a/pkg/protoport/port.go
+++ b/pkg/protoport/port.go
@@ -24,6 +24,7 @@ type (
 	AckMsg         struct{ A syncproto.Ack }
 	DeltaNackMsg   struct{ N syncproto.DeltaNack }
 	SyncBeginMsg   struct{}
+	SyncEndMsg     struct{}
 	RootMsg        struct{ R syncproto.Root }
 	DescentReqMsg  struct{ R syncproto.DescentReq }
 	DescentRespMsg struct{ R syncproto.DescentResp }
@@ -43,6 +44,7 @@ func (DeltaChunkMsg) isMessage()  {}
 func (AckMsg) isMessage()         {}
 func (DeltaNackMsg) isMessage()   {}
 func (SyncBeginMsg) isMessage()   {}
+func (SyncEndMsg) isMessage()     {}
 func (RootMsg) isMessage()        {}
 func (DescentReqMsg) isMessage()  {}
 func (DescentRespMsg) isMessage() {}
@@ -108,6 +110,8 @@ func EncodeMessage(m Message) (mt byte, payload []byte, ok bool) {
 		return wire.MT_DELTA_NACK, syncproto.EncodeDeltaNack(x.N), true
 	case SyncBeginMsg:
 		return wire.MT_SYNC_BEGIN, nil, true
+	case SyncEndMsg:
+		return wire.MT_SYNC_END, nil, true
 	case RootMsg:
 		return wire.MT_SYNC_ROOT, syncproto.EncodeRoot(x.R), true
 	case DescentReqMsg:
@@ -217,8 +221,10 @@ func decodeFrame(frame []byte) (Message, bool) {
 		return PingMsg{}, true
 	case wire.MT_PONG:
 		return PongMsg{}, true
+	case wire.MT_SYNC_BEGIN:
+		return SyncBeginMsg{}, true
 	case wire.MT_SYNC_END:
-		return SummaryReqMsg{}, true // placeholder to avoid unknown type; node handles END on wire path
+		return SyncEndMsg{}, true
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
Add `SyncEndMsg` type and proper handling to fix `MT_SYNC_END` message inconsistency in the typed messenger.

Previously, `pkg/protoport/port.go` returned a `SummaryReqMsg{}` placeholder for `wire.MT_SYNC_END` frames, leading to a silent inconsistency where session termination messages were misrepresented at the typed boundary. This change ensures `MT_SYNC_END` frames are correctly typed as `SyncEndMsg` and handled appropriately in `pkg/node/node.go`, ensuring proper session termination.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4d86538-538a-4020-a181-9aea11800e07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4d86538-538a-4020-a181-9aea11800e07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

